### PR TITLE
Fixed mouse coordinate calculation error when scrolling

### DIFF
--- a/main.js
+++ b/main.js
@@ -194,8 +194,10 @@ updatePallet();
 
 
 function getXY(evt){
+    // ref: https://stackoverflow.com/questions/28633221/document-body-scrolltop-firefox-returns-0-only-js
+    var scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0
     var x = Math.floor((evt.x - evt.target.offsetLeft) / scale);
-    var y = Math.floor((evt.y - evt.target.offsetTop + document.body.scrollTop) / scale);
+    var y = Math.floor((evt.y - evt.target.offsetTop + scrollTop) / scale);
     return {
         x: x,
         y: y


### PR DESCRIPTION
`document.body.scrollTop` constantly returns 0 in Chrome 70, breaking the cursor position on the editor canvas whenever the user scrolls; fixed it by getting scroll position in a different way.